### PR TITLE
Add installable entrypoint to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,11 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/yuvipanda/pre-commit-hook-ensure-sops",
     packages=setuptools.find_packages(),
+    entry_points={
+        "console_scripts": [
+            "pre-commit-hook-ensure-sops = pre_commit_hook_ensure_sops.__main__:main",
+        ]
+    },
     install_requires=[
         "ruamel.yaml",
     ],


### PR DESCRIPTION
No entrypoint exists in `setup.py` for easy use of the project in tools beyond `pre-commit`.

So I added the entrypoint to `setup.py` . It calls the `__main__.py` `main` function entrypoint so should just work and require no further effort except when the `__main__.py` entrypoint is renamed/changed.