### PR TITLE
Adds support for multiple documents in a YAML file and encrypted_regex options

### DIFF
--- a/pre_commit_hook_ensure_sops/__main__.py
+++ b/pre_commit_hook_ensure_sops/__main__.py
@@ -76,6 +76,9 @@ def check_file(filename, args):
             # present, very likely the file is not encrypted.
             return False, f"{filename}: sops metadata key not found in file, is not properly encrypted"
 
+        # Checks for the presense of the encrypted_regex key within the sops section
+        # if present sets the encrypted regex value to the value of this key
+        # otherwise, sets the value to "match all strings" \S regex
         if 'encrypted_regex' in doc['sops']:
             encrypted_regex = doc['sops']['encrypted_regex']
         else:

--- a/pre_commit_hook_ensure_sops/__main__.py
+++ b/pre_commit_hook_ensure_sops/__main__.py
@@ -50,7 +50,8 @@ def check_file(filename, args):
     if filename.endswith('.yaml'):
         if args.allow_multiple_documents:
             loader_func = _load_all
-        loader_func = yaml.load
+        else:
+            loader_func = yaml.load
     else:
         loader_func = json.load
     # sops doesn't have a --verify (https://github.com/mozilla/sops/issues/437)

--- a/pre_commit_hook_ensure_sops/__main__.py
+++ b/pre_commit_hook_ensure_sops/__main__.py
@@ -48,7 +48,7 @@ def check_file(filename, args):
     # We also leverage the _load_all function if the user specifies to allow muliple documents
     # in each individual YAML file
     if filename.endswith('.yaml'):
-        if args.allow_multiple:
+        if args.allow_multiple_documents:
             loader_func = _load_all
         loader_func = yaml.load
     else:


### PR DESCRIPTION
This PR adds two new features to the pre-commit hook.  Both primarily designed to make the hook work better in a kubernetes/flux workflow, but also helpful in other contexts like ansible playbooks.

First it allows multiple documents using an option matching the one used in the check_yaml hook provided by the upstream project [relevant PR](https://github.com/pre-commit/pre-commit-hooks/commit/e87b81afd90488b44364f7bb7e345d1e993271af) I tried to match their patterning as well as possible and make as few changes to the underlying code of this project as possible, but it may be better to do something like always using the `_load_all()` function and simply error out if there is more than one doc and the `-m` flag was not passed (or assume that multiple docs are fine and allow users to perform that type of check using the check_yaml hook itself).  I'm happy to make those changes if you'd like me to. fixes #12 

Second it adds support for sops `encrypted_regex` option, which limits the actual fields sops encrypts to only ones the user expects/intends to contain secrets.  This change looks for the `encrypted_regex` key within the sops configuration and uses it if available, if not, it uses `\S` to match any valid string (and so all keys). I omitted a flag for this one since the behavior remains unchanged for any file that does not include the `encrypted-regex` key, and any file that does specify it will always fail without this additional filtering, but I'm happy to add a flag if you feel that being explicit here is better, just let me know if you'd like to see that or any other changes before the commit.  fixes #13 