### PR TITLE
Add CI that runs unit tests (Closes #18)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,0 +1,17 @@
+on:
+  push:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install . pytest
+      - name: Run tests
+        run: pytest


### PR DESCRIPTION
Kept the workflow very simple (#18). One caveat is that `pytest`is explicitly installed in the workflow rather than provided by e.g. a `requirements-dev.txt` file. Might be a way to install it based on `test_requires` in `setup.py` but I am unfamiliar with the process.

Could expand this with e.g. a matrix to test different Python versions.